### PR TITLE
fix for SocketImpl usage

### DIFF
--- a/src/org/torproject/jtor/connections/ConnectionCache.java
+++ b/src/org/torproject/jtor/connections/ConnectionCache.java
@@ -16,8 +16,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
-import javax.net.ssl.SSLSocket;
-
 import org.torproject.jtor.circuits.Connection;
 import org.torproject.jtor.circuits.ConnectionFailedException;
 import org.torproject.jtor.circuits.ConnectionHandshakeException;
@@ -40,8 +38,7 @@ public class ConnectionCache implements DashboardRenderable {
 		}
 
 		public ConnectionImpl call() throws Exception {
-			SSLSocket socket = factory.createSocket();
-			ConnectionImpl conn = new ConnectionImpl(socket, router, initializationTracker, isDirectoryConnection);
+			ConnectionImpl conn = new ConnectionImpl(router, initializationTracker, isDirectoryConnection);
 			conn.connect();
 			return conn;
 		}
@@ -61,7 +58,6 @@ public class ConnectionCache implements DashboardRenderable {
 	}
 
 	private final ConcurrentMap<Router, Future<ConnectionImpl>> activeConnections = new ConcurrentHashMap<Router, Future<ConnectionImpl>>();
-	private final ConnectionSocketFactory factory = new ConnectionSocketFactory();
 	private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
 
 	private TorInitializationTracker initializationTracker;

--- a/src/org/torproject/jtor/sockets/JTorSocketImpl.java
+++ b/src/org/torproject/jtor/sockets/JTorSocketImpl.java
@@ -28,7 +28,7 @@ public class JTorSocketImpl extends SocketImpl {
 	}
 
 	public void setOption(int optID, Object value) throws SocketException {
-		throw new UnsupportedOperationException();
+		// don't throw exception here, this is required for original socket
 	}
 
 	public Object getOption(int optID) throws SocketException {


### PR DESCRIPTION
Hey,

this is my first commit now. When using JTorSocketImpl the connection manager also creates a SSLSocket by using this factory. I copied the "createOriginalSocket" method from silvertunnel and integrated it for JTor. I also wrote a little test script for myself to ensure that this will work.

The flags "isConnected" and "isClosed" where deleted, because you can check these flags from the socket itself.

Keep up this excellent work, it's awesome! :)
