### PR TITLE
Fix for Identity String in ConfigNodeFilter

### DIFF
--- a/src/com/subgraph/orchid/circuits/path/ConfigNodeFilter.java
+++ b/src/com/subgraph/orchid/circuits/path/ConfigNodeFilter.java
@@ -147,7 +147,7 @@ public class ConfigNodeFilter implements RouterFilter {
 	}
 	
 	private static RouterFilter createIdentityFilter(String s) {
-		if(isIdentityString(s)) {
+		if(!isIdentityString(s)) {
 			throw new IllegalArgumentException();
 		}
 		final HexDigest identity = HexDigest.createFromString(s);


### PR DESCRIPTION
Without it you can't use Fingerprint!
